### PR TITLE
ホストアドレスの修正

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -40,7 +40,7 @@ export default {
     };
   },
   mounted() {
-    this.socket = new WebSocket('ws://localhost:4400/ws');
+    this.socket = new WebSocket('ws://48.216.216.143:4400/ws');
 
     this.socket.addEventListener('open', (event) => {
       console.log('WebSocket connection opened:', event);

--- a/server/main.go
+++ b/server/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/websocket"
-	"github.com/joho/godotenv"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/joho/godotenv"
 )
 
 type NowPlayingResponse struct {
@@ -129,7 +130,7 @@ func main() {
 		values := url.Values{}
 		values.Add("client_id", os.Getenv("SPOTIFY_CLIENT_ID"))
 		values.Add("response_type", "code")
-		values.Add("redirect_uri", "http://localhost:4400/callback")
+		values.Add("redirect_uri", "http://127.0.0.1:4400/callback")
 		values.Add("scope", "user-read-playback-state user-read-currently-playing")
 		fmt.Println("https://accounts.spotify.com/authorize?" + values.Encode())
 

--- a/server/spotify.go
+++ b/server/spotify.go
@@ -19,7 +19,7 @@ func spotify_login(w http.ResponseWriter, req *http.Request) {
 	values := url.Values{}
 	values.Add("client_id", os.Getenv("SPOTIFY_CLIENT_ID"))
 	values.Add("response_type", "code")
-	values.Add("redirect_uri", "http://localhost:4400/callback")
+	values.Add("redirect_uri", "http://127.0.0.1:4400/callback")
 	values.Add("scope", "user-read-playback-state user-read-currently-playing")
 
 	http.Redirect(w, req, "https://accounts.spotify.com/authorize?"+values.Encode(), http.StatusFound)
@@ -48,7 +48,7 @@ func save_refresh_token(auth_code string) {
 	values.Set("grant_type", "authorization_code")
 	values.Set("code", auth_code)
 
-	values.Set("redirect_uri", "http://localhost:4400/callback")
+	values.Set("redirect_uri", "http://127.0.0.1:4400/callback")
 	req, err := http.NewRequest(http.MethodPost, "https://accounts.spotify.com/api/token", strings.NewReader(values.Encode()))
 	if err != nil {
 		log.Println("POSTリクエストの送信に失敗しました。: %s", err)


### PR DESCRIPTION
https://developer.spotify.com/blog/2025-02-12-increasing-the-security-requirements-for-integrating-with-spotify

Spotify側の規約の変更を受けて、作成したアプリが停止されないように、ローカルホストアドレスをコールバックアドレスに変更します。