### PR TITLE
WSの参照時間を修正

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -98,7 +98,7 @@ func sendNowPlayingUpdatesToWebSocket() {
 
 			broadcast <- response
 
-			time.Sleep(5 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
Webで表示する間隔があまりにも遅いので、WSに送信した後の待機時間を縮めます。